### PR TITLE
Add setTokenURI to ERC721Token

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,5 @@
 module.exports = {
+  configureYulOptimizer: true,
   testCommand:
     "node --max-old-space-size=4096 ../node_modules/.bin/truffle test test/TokenExtension.test.js --network coverage",
   compileCommand:

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -65,6 +65,6 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
   }
 
   function _burn(uint256 tokenId) internal virtual override(ERC721, ERC721URIStorage) {
-    ERC721URIStorage._burn(tokenId);
+      ERC721URIStorage._burn(tokenId);
   }
 }

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -35,6 +35,10 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
       return ERC721URIStorage.tokenURI(tokenId);
   }
 
+  function setTokenURI(uint256 tokenId, string memory uri) public virtual onlyMinter {
+      _setTokenURI(tokenId, uri);
+  }
+
   function _baseURI() internal view override virtual returns (string memory) {
       return _baseUri;
   }

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -28,21 +28,13 @@ contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC72
       _mint(to, tokenId);
       return true;
   }
-
+  
   /**
-  * @dev Function to mint tokens
-  * @param to The address that will receive the minted tokens.
-  * @param tokenId The token id to mint.
-  * @param uri The URI to give the tokenId.
-  * @return A boolean that indicates if the operation was successful.
+  * @dev Function to set a URI for a given tokenId
+  * @param tokenId The tokenId to assign the given URI
+  * @param uri The URI to give the given tokenId
   */
-  function mint(address to, uint256 tokenId, string memory uri) public onlyMinter returns (bool) {
-      _mint(to, tokenId);
-      setTokenUri(tokenId, uri);
-      return true;
-  }
-
-  function setTokenUri(uint256 tokenId, string memory uri) public virtual onlyMinter returns (bool) {
+  function setTokenUri(uint256 tokenId, string memory uri) external virtual onlyMinter returns (bool) {
       require(_exists(tokenId), "ERC721Metadata: Setting URI for nonexistent token");
       _tokenUris[tokenId] = uri;
       return true;

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -6,16 +6,18 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Pausable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "../interface/ERC1820Implementer.sol";
 import "../roles/MinterRole.sol";
 
-contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable {
+contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable {
   string constant internal ERC721_TOKEN = "ERC721Token";
-  mapping(uint256 => string) _tokenUris;
+  string internal _baseUri;
 
-  constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+  constructor(string memory name, string memory symbol, string memory baseUri) ERC721(name, symbol) {
     ERC1820Implementer._setInterface(ERC721_TOKEN);
+    _baseUri = baseUri;
   }
 
   /**
@@ -28,30 +30,13 @@ contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC72
       _mint(to, tokenId);
       return true;
   }
-  
-  /**
-  * @dev Function to set a URI for a given tokenId
-  * @param tokenId The tokenId to assign the given URI
-  * @param uri The URI to give the given tokenId
-  */
-  function setTokenUri(uint256 tokenId, string memory uri) external virtual onlyMinter returns (bool) {
-      require(_exists(tokenId), "ERC721Metadata: Setting URI for nonexistent token");
-      _tokenUris[tokenId] = uri;
-      return true;
+
+  function tokenURI(uint256 tokenId) public view virtual override(ERC721, ERC721URIStorage) returns (string memory) {
+      return ERC721URIStorage.tokenURI(tokenId);
   }
 
-  /**
-    * @dev See {IERC721Metadata-tokenURI}.
-    */
-  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-      require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
-
-      string memory uri = _tokenUris[tokenId];
-      if (bytes(uri).length > 0) {
-        return uri;
-      } else {
-        return super.tokenURI(tokenId);
-      }
+  function _baseURI() internal view override virtual returns (string memory) {
+      return _baseUri;
   }
 
   function _beforeTokenTransfer(
@@ -73,5 +58,9 @@ contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC72
       returns (bool)
   {
       return super.supportsInterface(interfaceId);
+  }
+
+  function _burn(uint256 tokenId) internal virtual override(ERC721, ERC721URIStorage) {
+    ERC721URIStorage._burn(tokenId);
   }
 }

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -12,6 +12,7 @@ import "../roles/MinterRole.sol";
 
 contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable {
   string constant internal ERC721_TOKEN = "ERC721Token";
+  mapping(uint256 => string) _tokenUris;
 
   constructor(string memory name, string memory symbol) ERC721(name, symbol) {
     ERC1820Implementer._setInterface(ERC721_TOKEN);
@@ -26,6 +27,39 @@ contract ERC721Token is Ownable, ERC721, ERC721Enumerable, ERC721Burnable, ERC72
   function mint(address to, uint256 tokenId) public onlyMinter returns (bool) {
       _mint(to, tokenId);
       return true;
+  }
+
+  /**
+  * @dev Function to mint tokens
+  * @param to The address that will receive the minted tokens.
+  * @param tokenId The token id to mint.
+  * @param uri The URI to give the tokenId.
+  * @return A boolean that indicates if the operation was successful.
+  */
+  function mint(address to, uint256 tokenId, string memory uri) public onlyMinter returns (bool) {
+      _mint(to, tokenId);
+      setTokenUri(tokenId, uri);
+      return true;
+  }
+
+  function setTokenUri(uint256 tokenId, string memory uri) public virtual onlyMinter returns (bool) {
+      require(_exists(tokenId), "ERC721Metadata: Setting URI for nonexistent token");
+      _tokenUris[tokenId] = uri;
+      return true;
+  }
+
+  /**
+    * @dev See {IERC721Metadata-tokenURI}.
+    */
+  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+      require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+
+      string memory uri = _tokenUris[tokenId];
+      if (bytes(uri).length > 0) {
+        return uri;
+      } else {
+        return super.tokenURI(tokenId);
+      }
   }
 
   function _beforeTokenTransfer(

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "lint-staged": "^10.4.0",
     "remix-ide": "^0.10.3",
     "sol-merger": "0.1.4",
-    "solidity-coverage": "0.7.16",
+    "solidity-coverage": "0.8.0-beta.0",
     "solium": "^1.2.5",
     "solium-plugin-zeppelin": "^0.0.2",
     "web3-utils": "^1.2.8"

--- a/test/DVP.test.js
+++ b/test/DVP.test.js
@@ -3771,6 +3771,12 @@ contract("DVP", function ([
                       from: owner,
                     });
                   });
+                  it("setTokenURI sets the URI for the tokenId", async function() {
+                    await this.security721.setTokenUri(issuanceTokenId, "https://consensys.org/" + issuanceTokenId);
+                    const uri = await this.security721.tokenURI(issuanceTokenId);
+
+                    assert.equal(uri, "https://consensys.org/" + issuanceTokenId)
+                  });
                   describe("when trade type is Escrow", function () {
                     it("executes the trade", async function () {
                       await this.security721.approve(

--- a/test/DVP.test.js
+++ b/test/DVP.test.js
@@ -3772,7 +3772,7 @@ contract("DVP", function ([
                     });
                   });
                   it("setTokenURI sets the URI for the tokenId", async function() {
-                    await this.security721.setTokenUri(issuanceTokenId, "https://consensys.org/" + issuanceTokenId);
+                    await this.security721.setTokenURI(issuanceTokenId, "https://consensys.org/" + issuanceTokenId);
                     const uri = await this.security721.tokenURI(issuanceTokenId);
 
                     assert.equal(uri, "https://consensys.org/" + issuanceTokenId)

--- a/test/DVP.test.js
+++ b/test/DVP.test.js
@@ -1887,7 +1887,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721", function () {
                   it("creates and accepts the trade request", async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });
@@ -2003,7 +2003,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721", function () {
                   it("creates and accepts the trade request", async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });
@@ -2752,7 +2752,7 @@ contract("DVP", function ([
         });
         describe("when token standard is ERC721", function () {
           beforeEach(async function () {
-            this.security721 = await ERC721.new("ERC721Token", "DAU721");
+            this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
             this.token2 = this.security721;
             await this.token2.mint(recipient1, issuanceTokenId, {
               from: owner,
@@ -3766,7 +3766,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721 vs ERC20", function () {
                   beforeEach(async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });

--- a/test/TokenExtension.test.js
+++ b/test/TokenExtension.test.js
@@ -339,30 +339,40 @@ contract("ERC1400HoldableCertificate with token extension", function ([
   tokenController2
 ]) {
   before(async function () {
-    this.registry = await ERC1820Registry.at(
-      "0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24"
-    );
+    try {
+      this.registry = await ERC1820Registry.at(
+        "0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24"
+      );
 
-    this.clock = await ClockMock.new();
+      this.clock = await ClockMock.new();
 
-    this.extension = await ERC1400TokensValidator.new({
-      from: deployer,
-    });
+      this.extension = await ERC1400TokensValidator.new({
+        from: deployer,
+      });
+    } catch (e) {
+      console.log(e);
+      assert.ok(false);
+    }
   });
 
   beforeEach(async function () {
-    this.token = await ERC1400HoldableCertificate.new(
-      "ERC1400Token",
-      "DAU",
-      1,
-      [controller],
-      partitions,
-      this.extension.address,
-      owner,
-      CERTIFICATE_SIGNER,
-      CERTIFICATE_VALIDATION_DEFAULT,
-      { from: controller }
-    );
+    try {
+      this.token = await ERC1400HoldableCertificate.new(
+        "ERC1400Token",
+        "DAU",
+        1,
+        [controller],
+        partitions,
+        this.extension.address,
+        owner,
+        CERTIFICATE_SIGNER,
+        CERTIFICATE_VALIDATION_DEFAULT,
+        { from: controller }
+      );
+    } catch (e) {
+      console.log(e);
+      assert.ok(false);
+    }
   });
 
   // MOCK
@@ -387,6 +397,7 @@ contract("ERC1400HoldableCertificate with token extension", function ([
       describe("when the the validator contract is not already a minter", function () {
         describe("when there is was no previous validator contract", function () {
           it("sets the token extension", async function () {
+            console.log('1')
             this.token = await ERC1400HoldableCertificate.new(
               "ERC1400Token",
               "DAU",
@@ -399,16 +410,22 @@ contract("ERC1400HoldableCertificate with token extension", function ([
               CERTIFICATE_VALIDATION_DEFAULT,
               { from: controller }
             );
+            console.log('2')
 
             assert.equal(await this.token.owner(), owner)
+            console.log('3')
 
             let extensionImplementer = await this.registry.getInterfaceImplementer(
               this.token.address,
               soliditySha3(ERC1400_TOKENS_VALIDATOR)
             );
+            console.log('4')
             assert.equal(extensionImplementer, ZERO_ADDRESS);
+            console.log('5')
             assert.equal(await this.token.isOperator(this.extension.address, unknown), false)
+            console.log('6')
             assert.equal(await this.token.isMinter(this.extension.address), false)
+            console.log('7')
     
             await this.token.setTokenExtension(
               this.extension.address,
@@ -418,14 +435,19 @@ contract("ERC1400HoldableCertificate with token extension", function ([
               true,
               { from: owner }
             );
+            console.log('8')
     
             extensionImplementer = await this.registry.getInterfaceImplementer(
               this.token.address,
               soliditySha3(ERC1400_TOKENS_VALIDATOR)
             );
+            console.log('9')
             assert.equal(extensionImplementer, this.extension.address);
+            console.log('10')
             assert.equal(await this.token.isOperator(this.extension.address, unknown), true)
+            console.log('11')
             assert.equal(await this.token.isMinter(this.extension.address), true)
+            console.log('12')
           });
         });
         describe("when there is was a previous validator contract", function () {
@@ -1624,18 +1646,21 @@ contract("ERC1400HoldableCertificate with token extension", function ([
       );
     });
     after(async function () {
+      console.log('aaaa')
       await this.registry.setInterfaceImplementer(
         tokenHolder,
         soliditySha3(ERC1400_TOKENS_SENDER),
         ZERO_ADDRESS,
         { from: tokenHolder }
       );
+      console.log('bbbb')
       await this.registry.setInterfaceImplementer(
         recipient,
         soliditySha3(ERC1400_TOKENS_RECIPIENT),
         ZERO_ADDRESS,
         { from: recipient }
       );
+      console.log('cccc')
     });
 
     beforeEach(async function () {

--- a/test/TokenExtension.test.js
+++ b/test/TokenExtension.test.js
@@ -339,40 +339,30 @@ contract("ERC1400HoldableCertificate with token extension", function ([
   tokenController2
 ]) {
   before(async function () {
-    try {
-      this.registry = await ERC1820Registry.at(
-        "0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24"
-      );
+    this.registry = await ERC1820Registry.at(
+      "0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24"
+    );
 
-      this.clock = await ClockMock.new();
+    this.clock = await ClockMock.new();
 
-      this.extension = await ERC1400TokensValidator.new({
-        from: deployer,
-      });
-    } catch (e) {
-      console.log(e);
-      assert.ok(false);
-    }
+    this.extension = await ERC1400TokensValidator.new({
+      from: deployer,
+    });
   });
 
   beforeEach(async function () {
-    try {
-      this.token = await ERC1400HoldableCertificate.new(
-        "ERC1400Token",
-        "DAU",
-        1,
-        [controller],
-        partitions,
-        this.extension.address,
-        owner,
-        CERTIFICATE_SIGNER,
-        CERTIFICATE_VALIDATION_DEFAULT,
-        { from: controller }
-      );
-    } catch (e) {
-      console.log(e);
-      assert.ok(false);
-    }
+    this.token = await ERC1400HoldableCertificate.new(
+      "ERC1400Token",
+      "DAU",
+      1,
+      [controller],
+      partitions,
+      this.extension.address,
+      owner,
+      CERTIFICATE_SIGNER,
+      CERTIFICATE_VALIDATION_DEFAULT,
+      { from: controller }
+    );
   });
 
   // MOCK

--- a/test/TokenExtension.test.js
+++ b/test/TokenExtension.test.js
@@ -1648,21 +1648,18 @@ contract("ERC1400HoldableCertificate with token extension", function ([
       );
     });
     after(async function () {
-      console.log('aaaa')
       await this.registry.setInterfaceImplementer(
         tokenHolder,
         soliditySha3(ERC1400_TOKENS_SENDER),
         ZERO_ADDRESS,
         { from: tokenHolder }
       );
-      console.log('bbbb')
       await this.registry.setInterfaceImplementer(
         recipient,
         soliditySha3(ERC1400_TOKENS_RECIPIENT),
         ZERO_ADDRESS,
         { from: recipient }
       );
-      console.log('cccc')
     });
 
     beforeEach(async function () {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -40,8 +40,7 @@ module.exports = {
       network_id: '*', // eslint-disable-line camelcase
       port: 8555,
       gas: 0xfffffffffff,
-      gasPrice: 0x01,
-      disableConfirmationListener: true
+      gasPrice: 0x01
     },
     ganache: {
       host: 'localhost',

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -41,6 +41,7 @@ module.exports = {
       port: 8555,
       gas: 0xfffffffffff,
       gasPrice: 0x01,
+      disableConfirmationListener: true
     },
     ganache: {
       host: 'localhost',

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,21 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/abi@^5.0.9":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.1.tgz#6ac28fafc9ef6f5a7a37e30356a2eb31fa05d39b"
+  integrity sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
@@ -690,7 +705,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
 
-"@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.0.4":
+"@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.0.4", "@ethersproject/hash@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
   integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
@@ -1364,10 +1379,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@solidity-parser/parser@^0.12.0":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.2.tgz#1afad367cb29a2ed8cdd4a3a62701c2821fb578f"
-  integrity sha512-d7VS7PxgMosm5NyaiyDJRNID5pK4AWj1l64Dbz0147hJgy5k2C0/ZiKK/9u5c5K+HRUVHmp+RMvGEjGh84oA5Q==
+"@solidity-parser/parser@^0.11.0":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.1.tgz#fa840af64840c930f24a9c82c08d4a092a068add"
+  integrity sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -2378,6 +2393,11 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+
+ansi-colors@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
+  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
 
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
@@ -4226,6 +4246,21 @@ cheerio@1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
+chokidar@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
+  integrity sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.2.0"
+  optionalDependencies:
+    fsevents "~2.1.1"
+
 chokidar@3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
@@ -4898,6 +4933,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
 debug@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -5121,15 +5163,15 @@ diff@3.3.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
   integrity sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
 
+diff@3.5.0, diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 diff@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-diff@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5139,6 +5181,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+difflib@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e"
+  integrity sha1-teMDYabbAjF21WKJLbhZQKcY9H4=
+  dependencies:
+    heap ">= 0.2.0"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -6720,6 +6769,13 @@ find-root@^1.0.0:
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
+find-up@3.0.0, find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -6742,13 +6798,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -6963,7 +7012,7 @@ fsevents@^1.0.0:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.1.2:
+fsevents@~2.1.1, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
@@ -7172,6 +7221,18 @@ glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -7612,6 +7673,11 @@ header-case@^1.0.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.3"
+
+"heap@>= 0.2.0":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
+  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
 hmac-drbg@^1.0.0, hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -8762,6 +8828,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
@@ -9423,6 +9497,13 @@ lodash@^4.0.0, lodash@^4.14.2, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+log-symbols@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
 log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -9833,12 +9914,42 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@0.5.5, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mocha@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
+  integrity sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
+  dependencies:
+    ansi-colors "3.2.3"
+    browser-stdout "1.3.1"
+    chokidar "3.3.0"
+    debug "3.2.6"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    find-up "3.0.0"
+    glob "7.1.3"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "3.13.1"
+    log-symbols "3.0.0"
+    minimatch "3.0.4"
+    mkdirp "0.5.5"
+    ms "2.1.1"
+    node-environment-flags "1.0.6"
+    object.assign "4.1.0"
+    strip-json-comments "2.0.1"
+    supports-color "6.0.0"
+    which "1.3.1"
+    wide-align "1.1.3"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
+    yargs-unparser "1.6.0"
 
 mocha@8.1.2:
   version "8.1.2"
@@ -10217,6 +10328,14 @@ node-emoji@^1.10.0:
   dependencies:
     lodash "^4.17.21"
 
+node-environment-flags@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
+  integrity sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==
+  dependencies:
+    object.getownpropertydescriptors "^2.0.3"
+    semver "^5.7.0"
+
 node-fetch@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.4.1.tgz#b2e38f1117b8acbedbe0524f041fb3177188255d"
@@ -10483,7 +10602,7 @@ object.assign@^4.1.0, object.assign@^4.1.1, object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
-object.getownpropertydescriptors@^2.1.1:
+object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
   integrity sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
@@ -11791,6 +11910,13 @@ readdirp@^2.0.0:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readdirp@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
+  integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
+  dependencies:
+    picomatch "^2.0.4"
+
 readdirp@~3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
@@ -12445,7 +12571,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -12778,16 +12904,18 @@ sol-merger@0.1.4:
     fs-extra "^7.0.1"
     glob "^7.1.2"
 
-solidity-coverage@0.7.16:
-  version "0.7.16"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.7.16.tgz#c8c8c46baa361e2817bbf275116ddd2ec90a55fb"
-  integrity sha512-ttBOStywE6ZOTJmmABSg4b8pwwZfYKG8zxu40Nz+sRF5bQX7JULXWj/XbX0KXps3Fsp8CJXg8P29rH3W54ipxw==
+solidity-coverage@0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.0-beta.0.tgz#c0b70d15c2c15b3242b64178878fe4ad1f9fe81e"
+  integrity sha512-U+OeAJLEqoHJDD7eothMRpNPLcEKfk0q2gwSgCfXEaXusiwVKTs8jqNVKyfucANEWof88dt0IvxBmGpxh5BtmQ==
   dependencies:
-    "@solidity-parser/parser" "^0.12.0"
+    "@ethersproject/abi" "^5.0.9"
+    "@solidity-parser/parser" "^0.11.0"
     "@truffle/provider" "^0.2.24"
     chalk "^2.4.2"
     death "^1.1.0"
     detect-port "^1.3.0"
+    difflib "^0.2.4"
     fs-extra "^8.1.0"
     ganache-cli "^6.11.0"
     ghost-testrpc "^0.0.2"
@@ -12795,6 +12923,7 @@ solidity-coverage@0.7.16:
     globby "^10.0.1"
     jsonschema "^1.2.4"
     lodash "^4.17.15"
+    mocha "7.1.2"
     node-emoji "^1.10.0"
     pify "^4.0.1"
     recursive-readdir "^2.2.2"
@@ -13216,6 +13345,11 @@ strip-hex-prefix@1.0.0:
   dependencies:
     is-hex-prefixed "1.0.0"
 
+strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
 strip-json-comments@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
@@ -13230,11 +13364,6 @@ strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 sublevel-pouchdb@7.2.2:
   version "7.2.2"
@@ -13263,6 +13392,13 @@ supports-color@4.4.0:
   integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
+  integrity sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@7.1.0:
   version "7.1.0"
@@ -14587,17 +14723,17 @@ which-typed-array@^1.1.2:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.6"
 
+which@1.3.1, which@^1.1.1, which@^1.2.9, which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@2.0.2, which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.1.1, which@^1.2.9, which@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -14859,6 +14995,15 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-unparser@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.0.tgz#ef25c2c769ff6bd09e4b0f9d7c605fb27846ea9f"
+  integrity sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==
+  dependencies:
+    flat "^4.1.0"
+    lodash "^4.17.15"
+    yargs "^13.3.0"
+
 yargs-unparser@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.1.tgz#bd4b0ee05b4c94d058929c32cb09e3fce71d3c5f"
@@ -14887,7 +15032,7 @@ yargs@13.2.4:
     y18n "^4.0.0"
     yargs-parser "^13.1.0"
 
-yargs@13.3.2:
+yargs@13.3.2, yargs@^13.3.0:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==


### PR DESCRIPTION
## Description

This adds the `setTokenUri` function to the `ERC721Token` using the `ERC721URIStorage` extension contract. The `baseUri` can be specified on contract creation in the constructor. The `baseUri` is prepended to the start of the `tokenUri` set in `setTokenUri`, however it can be left blank to allow tokens to have data from multiple domains

## Motivation and Context

This allows an NFT contract to set a URI for a given `tokenId` to a specific URI

## How Has This Been Tested?

A unit test is included in this PR

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
