### PR TITLE
Remove DomainAware from ERC20Token and ERC721Token

### DIFF
--- a/contracts/tokens/ERC20Token.sol
+++ b/contracts/tokens/ERC20Token.sol
@@ -7,9 +7,8 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
 
 import "../interface/ERC1820Implementer.sol";
 import "../roles/MinterRole.sol";
-import "../tools/DomainAware.sol";
 
-contract ERC20Token is Ownable, ERC20Burnable, ERC20Pausable, ERC1820Implementer, MinterRole, DomainAware {
+contract ERC20Token is Ownable, ERC20Burnable, ERC20Pausable, ERC1820Implementer, MinterRole {
   string constant internal ERC20_TOKEN = "ERC20Token";
   uint8 immutable internal _decimals;
 
@@ -55,12 +54,12 @@ contract ERC20Token is Ownable, ERC20Burnable, ERC20Pausable, ERC1820Implementer
   }
 
   /************************************* Domain Aware ******************************************/
-  function domainName() public override view returns (string memory) {
+/*  function domainName() public override view returns (string memory) {
     return name();
   }
 
   function domainVersion() public override view returns (string memory) {
     return "1";
-  }
+  }*/
   /************************************************************************************************/
 }

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -10,9 +10,8 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "../interface/ERC1820Implementer.sol";
 import "../roles/MinterRole.sol";
-import "../tools/DomainAware.sol";
 
-contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable, DomainAware {
+contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable {
   string constant internal ERC721_TOKEN = "ERC721Token";
   string internal _baseUri;
 
@@ -70,12 +69,12 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
   }
 
   /************************************* Domain Aware ******************************************/
-  function domainName() public override view returns (string memory) {
+/*  function domainName() public override view returns (string memory) {
     return name();
   }
 
   function domainVersion() public override view returns (string memory) {
     return "1";
-  }
+  }*/
   /************************************************************************************************/
 }


### PR DESCRIPTION
## Description

Removes the `DomainAware` contract from `ERC20Token` and `ERC721Token`

## Motivation and Context

Currently, the `DomainAware` uses the `chainId` opcode to determine what chain the current Contract is running on. However, some internal tools do not support this opcode (yet), and since these tokens aren't ever doing any signing verification (unlike `ERC1400Token`) it is safe to remove for now to get internal tools working.

Once internal tools have been updated to support the `chainId` opcode, this should be added back to these contracts

## How Has This Been Tested?

All unit tests are passing, currently nothing was using the `DomainAware` contract for `ERC20Token` and `ERC721Token`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
