### PR TITLE
Fix bug: cannot run unit tests

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -4,7 +4,11 @@ module.exports = {
     "node --max-old-space-size=4096 ../node_modules/.bin/truffle test test/TokenExtension.test.js --network coverage",
   compileCommand:
     "node --max-old-space-size=4096 ../node_modules/.bin/truffle compile --network coverage",
-  skipFiles: ["tokens/ERC20Token", "tokens/ERC721Token", "tools/FundIssuer"],
+  skipFiles: ["tokens/ERC20Token", "tokens/ERC721Token", "tools/FundIssuer", 
+    "extensions/allowblock/allow/IAllowlistedAdminRole.sol",
+    "extensions/allowblock/allow/IAllowlistedRole.sol",
+    "extensions/allowblock/block/IBlocklistedAdminRole.sol",
+    "extensions/allowblock/block/IBlocklistedRole.sol"],
   copyPackages: ["@openzeppelin/contracts"],
   mocha: {
     enableTimeouts: false,


### PR DESCRIPTION
The instrumentation code that `solidity-coverage` adds to files that declared/defined modifiers in interface (IAllowlistedAdminRole.sol, IAllowlistedRole.sol, IBlocklistedAdminRole.sol, IBlocklistedRole.sol) is not declared so it cause out error.

I fixed bug that I have reported at #135. 

Please review it! Thanks.