### PR TITLE
feat: add contract uri and set token uri on mint to erc721

### DIFF
--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -14,10 +14,12 @@ import "../roles/MinterRole.sol";
 contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable, ERC721Pausable,  MinterRole, ERC1820Implementer, AccessControlEnumerable {
   string constant internal ERC721_TOKEN = "ERC721Token";
   string internal _baseUri;
+  string internal _contractUri;
 
-  constructor(string memory name, string memory symbol, string memory baseUri) ERC721(name, symbol) {
+  constructor(string memory name, string memory symbol, string memory baseUri, string memory contractUri) ERC721(name, symbol) {
     ERC1820Implementer._setInterface(ERC721_TOKEN);
     _baseUri = baseUri;
+    _contractUri = contractUri;
   }
 
   /**
@@ -28,6 +30,12 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
   */
   function mint(address to, uint256 tokenId) public onlyMinter returns (bool) {
       _mint(to, tokenId);
+      return true;
+  }
+  
+  function mint(address to, uint256 tokenId, string memory uri) public onlyMinter returns (bool) {
+      _mint(to, tokenId);
+      _setTokenURI(tokenId, uri);
       return true;
   }
 
@@ -66,6 +74,14 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
 
   function _burn(uint256 tokenId) internal virtual override(ERC721, ERC721URIStorage) {
       ERC721URIStorage._burn(tokenId);
+  }
+
+  function setContractURI(string memory uri) public virtual onlyOwner {
+      _contractUri = uri;
+  }
+
+  function contractURI() public view returns (string memory) {
+    return _contractUri;
   }
 
   /************************************* Domain Aware ******************************************/

--- a/test/DVP.test.js
+++ b/test/DVP.test.js
@@ -2047,7 +2047,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721", function () {
                   it("creates and accepts the trade request", async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });
@@ -2163,7 +2163,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721", function () {
                   it("creates and accepts the trade request", async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });
@@ -2864,7 +2864,7 @@ contract("DVP", function ([
         });
         describe("when token standard is ERC721", function () {
           beforeEach(async function () {
-            this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
+            this.security721 = await ERC721.new("ERC721Token", "DAU721", "", "");
             this.token2 = this.security721;
             await this.token2.mint(recipient1, issuanceTokenId, {
               from: owner,
@@ -3878,7 +3878,7 @@ contract("DVP", function ([
                 });
                 describe("when token standard is ERC721 vs ERC20", function () {
                   beforeEach(async function () {
-                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "");
+                    this.security721 = await ERC721.new("ERC721Token", "DAU721", "", "");
                     await this.security721.mint(tokenHolder1, issuanceTokenId, {
                       from: owner,
                     });


### PR DESCRIPTION
## Description
Updated erc721 token contract to:
* add a contractURI will allow OS to discover collection metadata easily.
* setting a tokenURI on mint will allow us to avoid an extra trx to set a tokenURI.

## Motivation and Context
We want to have an erc721 contract that would allow us to easily have collections being available on OS (and similar platforms). In order to do that we are adding a contractURI for retrieving collection metadata (https://docs.opensea.io/docs/contract-level-metadata).

Besides that we have also decided to add the possibility to set a tokenURI on the mint function (in most cases we will already have a URI where from where the metadata for a given token can be retrieved, so we can avoid doing another trx just to set the token URI).
This parameter is optional (mint should work without setting a tokenURI as well).

## How Has This Been Tested?
Only using the existing unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
