### PR TITLE
fix: split mint overload into different methods

### DIFF
--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -33,7 +33,7 @@ contract ERC721Token is Ownable, ERC721, ERC721URIStorage, ERC721Enumerable, ERC
       return true;
   }
   
-  function mint(address to, uint256 tokenId, string memory uri) public onlyMinter returns (bool) {
+  function mintAndSetTokenURI(address to, uint256 tokenId, string memory uri) public onlyMinter returns (bool) {
       _mint(to, tokenId);
       _setTokenURI(tokenId, uri);
       return true;


### PR DESCRIPTION
## Description

Split the mint overload into different methods. In this case we are introducing the `mintAndSetTokenURI` method.

## Motivation and Context

We need to split this into different methods in order to be able to expose different API routes for each.
Currently we have a micro service that allows to call smart contract methods via API, which is quite convenient.
The downsize is that it does not support overloading.

## How Has This Been Tested?

Current unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
