### PR TITLE
Address all solidity compiler (`solc`) warnings.

### DIFF
--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -179,9 +179,7 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
     uint256 granularity,
     address[] memory controllers,
     bytes32[] memory defaultPartitions
-  )
-    public
-  {
+  ) {
     _name = name;
     _symbol = symbol;
     _totalSupply = 0;

--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -1437,7 +1437,7 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
     return _name;
   }
 
-  function domainVersion() public override view returns (string memory) {
+  function domainVersion() public override pure returns (string memory) {
     return "1";
   }
   /************************************************************************************************/

--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -166,27 +166,27 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
 
   /**
    * @dev Initialize ERC1400 + register the contract implementation in ERC1820Registry.
-   * @param name Name of the token.
-   * @param symbol Symbol of the token.
-   * @param granularity Granularity of the token.
-   * @param controllers Array of initial controllers.
+   * @param tokenName Name of the token.
+   * @param tokenSymbol Symbol of the token.
+   * @param tokenGranularity Granularity of the token.
+   * @param initialControllers Array of initial controllers.
    * @param defaultPartitions Partitions chosen by default, when partition is
    * not specified, like the case ERC20 tranfers.
    */
   constructor(
-    string memory name,
-    string memory symbol,
-    uint256 granularity,
-    address[] memory controllers,
+    string memory tokenName,
+    string memory tokenSymbol,
+    uint256 tokenGranularity,
+    address[] memory initialControllers,
     bytes32[] memory defaultPartitions
   ) {
-    _name = name;
-    _symbol = symbol;
+    _name = tokenName;
+    _symbol = tokenSymbol;
     _totalSupply = 0;
-    require(granularity >= 1); // Constructor Blocked - Token granularity can not be lower than 1
-    _granularity = granularity;
+    require(tokenGranularity >= 1); // Constructor Blocked - Token granularity can not be lower than 1
+    _granularity = tokenGranularity;
 
-    _setControllers(controllers);
+    _setControllers(initialControllers);
 
     _defaultPartitions = defaultPartitions;
 
@@ -284,26 +284,26 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
   /************************************* Document Management **************************************/
   /**
    * @dev Access a document associated with the token.
-   * @param name Short name (represented as a bytes32) associated to the document.
+   * @param documentName Short name (represented as a bytes32) associated to the document.
    * @return Requested document + document hash + document timestamp.
    */
-  function getDocument(bytes32 name) external override view returns (string memory, bytes32, uint256) {
-    require(bytes(_documents[name].docURI).length != 0); // Action Blocked - Empty document
+  function getDocument(bytes32 documentName) external override view returns (string memory, bytes32, uint256) {
+    require(bytes(_documents[documentName].docURI).length != 0); // Action Blocked - Empty document
     return (
-      _documents[name].docURI,
-      _documents[name].docHash,
-      _documents[name].timestamp
+      _documents[documentName].docURI,
+      _documents[documentName].docHash,
+      _documents[documentName].timestamp
     );
   }
   /**
    * @dev Associate a document with the token.
-   * @param name Short name (represented as a bytes32) associated to the document.
+   * @param documentName Short name (represented as a bytes32) associated to the document.
    * @param uri Document content.
    * @param documentHash Hash of the document [optional parameter].
    */
-  function setDocument(bytes32 name, string calldata uri, bytes32 documentHash) external override {
+  function setDocument(bytes32 documentName, string calldata uri, bytes32 documentHash) external override {
     require(_isController[msg.sender]);
-    _documents[name] = Doc({
+    _documents[documentName] = Doc({
       docURI: uri,
       docHash: documentHash,
       timestamp: block.timestamp
@@ -314,14 +314,14 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
       _indexOfDocHashes[documentHash] = _docHashes.length;
     }
 
-    emit DocumentUpdated(name, uri, documentHash);
+    emit DocumentUpdated(documentName, uri, documentHash);
   }
 
-  function removeDocument(bytes32 _name) external override {
+  function removeDocument(bytes32 documentName) external override {
     require(_isController[msg.sender], "Unauthorized");
-    require(bytes(_documents[_name].docURI).length != 0, "Document doesnt exist"); // Action Blocked - Empty document
+    require(bytes(_documents[documentName].docURI).length != 0, "Document doesnt exist"); // Action Blocked - Empty document
 
-    Doc memory data = _documents[_name];
+    Doc memory data = _documents[documentName];
 
     uint256 index1 = _indexOfDocHashes[data.docHash];
     require(index1 > 0, "Invalid index"); //Indexing starts at 1, 0 is not allowed
@@ -335,9 +335,9 @@ contract ERC1400 is IERC20, IERC1400, Ownable, ERC1820Client, ERC1820Implementer
     _docHashes.pop();
     _indexOfDocHashes[data.docHash] = 0;
 
-    delete _documents[_name];
+    delete _documents[documentName];
 
-    emit DocumentRemoved(_name, data.docURI, data.docHash);
+    emit DocumentRemoved(documentName, data.docURI, data.docHash);
   }
 
   function getAllDocuments() external override view returns (bytes32[] memory) {

--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/IERC1400.sol
+++ b/contracts/IERC1400.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 

--- a/contracts/certificate/ERC1400HoldableCertificateToken.sol
+++ b/contracts/certificate/ERC1400HoldableCertificateToken.sol
@@ -72,7 +72,6 @@ contract ERC1400HoldableCertificateToken is ERC1400, IExtensionTypes {
     address certificateSigner,
     CertificateValidation certificateActivated
   )
-    public
     ERC1400(name, symbol, granularity, controllers, defaultPartitions)
   {
     if(extension != address(0)) {

--- a/contracts/certificate/ERC1400HoldableCertificateToken.sol
+++ b/contracts/certificate/ERC1400HoldableCertificateToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/tokenExtensions/ERC1400TokensChecker.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensChecker.sol
@@ -34,7 +34,7 @@ contract ERC1400TokensChecker is IERC1400TokensChecker, ERC1820Client, ERC1820Im
   string constant internal ERC1400_TOKENS_SENDER = "ERC1400TokensSender";
   string constant internal ERC1400_TOKENS_RECIPIENT = "ERC1400TokensRecipient";
 
-  constructor() public {
+  constructor() {
     ERC1820Implementer._setInterface(ERC1400_TOKENS_CHECKER);
   }
 

--- a/contracts/extensions/tokenExtensions/ERC1400TokensChecker.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensChecker.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
@@ -470,9 +470,9 @@ contract ERC1400TokensValidator is IERC1400TokensValidator, Pausable, Certificat
     if (_holdsActivated[token] && from != address(0)) {
       if(operator != from) {
         (, bytes32 holdId) = _retrieveHoldHashId(token, partition, operator, from, to, value);
-        Hold storage hold = _holds[token][holdId];
+        Hold storage hold_ = _holds[token][holdId];
         
-        if (_holdCanBeExecutedAsNotary(hold, operator, value) && value <= IERC1400(token).balanceOfByPartition(partition, from)) {
+        if (_holdCanBeExecutedAsNotary(hold_, operator, value) && value <= IERC1400(token).balanceOfByPartition(partition, from)) {
           return true;
         }
       }

--- a/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
@@ -1018,7 +1018,7 @@ contract ERC1400TokensValidator is IERC1400TokensValidator, Pausable, Certificat
   /**
    * @dev Increase held balance.
    */
-  function _increaseHeldBalance(address token, Hold storage executableHold, bytes32 holdId) private {
+  function _increaseHeldBalance(address token, Hold storage executableHold, bytes32/*holdId*/) private {
     _heldBalance[token][executableHold.sender] = _heldBalance[token][executableHold.sender].add(executableHold.value);
     _totalHeldBalance[token] = _totalHeldBalance[token].add(executableHold.value);
 

--- a/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
@@ -878,8 +878,8 @@ contract ERC1400TokensValidator is IERC1400TokensValidator, Pausable, Certificat
   /**
    * @dev Execute hold.
    */
-  function executeHold(address token, bytes32 holdId, uint256 value, bytes32 secret) external override returns (bool) {
-    return _executeHold(
+  function executeHold(address token, bytes32 holdId, uint256 value, bytes32 secret) external override {
+    _executeHold(
       token,
       holdId,
       msg.sender,
@@ -892,8 +892,8 @@ contract ERC1400TokensValidator is IERC1400TokensValidator, Pausable, Certificat
   /**
    * @dev Execute hold and keep open.
    */
-  function executeHoldAndKeepOpen(address token, bytes32 holdId, uint256 value, bytes32 secret) external returns (bool) {
-    return _executeHold(
+  function executeHoldAndKeepOpen(address token, bytes32 holdId, uint256 value, bytes32 secret) external {
+    _executeHold(
       token,
       holdId,
       msg.sender,
@@ -913,7 +913,7 @@ contract ERC1400TokensValidator is IERC1400TokensValidator, Pausable, Certificat
     uint256 value,
     bytes32 secret,
     bool keepOpenIfHoldHasBalance
-  ) internal returns (bool)
+  ) internal
   {
     Hold storage executableHold = _holds[token][holdId];
 

--- a/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
+++ b/contracts/extensions/tokenExtensions/ERC1400TokensValidator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/tokenExtensions/IERC1400TokensChecker.sol
+++ b/contracts/extensions/tokenExtensions/IERC1400TokensChecker.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/tokenExtensions/IERC1400TokensValidator.sol
+++ b/contracts/extensions/tokenExtensions/IERC1400TokensValidator.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/userExtensions/IERC1400TokensRecipient.sol
+++ b/contracts/extensions/userExtensions/IERC1400TokensRecipient.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/extensions/userExtensions/IERC1400TokensSender.sol
+++ b/contracts/extensions/userExtensions/IERC1400TokensSender.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/interface/ERC1820Implementer.sol
+++ b/contracts/interface/ERC1820Implementer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/interface/HoldStatusCode.sol
+++ b/contracts/interface/HoldStatusCode.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 enum HoldStatusCode {

--- a/contracts/interface/IERC1643.sol
+++ b/contracts/interface/IERC1643.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 /// @title IERC1643 Document Management (part of the ERC1400 Security Token Standards)

--- a/contracts/interface/IERC20HoldableToken.sol
+++ b/contracts/interface/IERC20HoldableToken.sol
@@ -41,12 +41,12 @@ interface IERC20HoldableToken is IERC20 {
 
     /**
      @notice Called by the sender to hold some tokens for a recipient that the sender can not release back to themself until after the expiration date.
+     @param holdId a unique identifier for the hold.
      @param recipient optional account the tokens will be transferred to on execution. If a zero address, the recipient must be specified on execution of the hold.
      @param notary account that can execute the hold. Typically the recipient but can be a third party or a smart contact.
      @param amount of tokens to be transferred to the recipient on execution. Must be a non zero amount.
      @param expirationDateTime UNIX epoch seconds the held amount can be released back to the sender by the sender. Past dates are allowed.
      @param lockHash optional keccak256 hash of a lock preimage. An empty hash will not enforce the hash lock when the hold is executed.
-     @return bool Whether the call was successful or not.
      */
     function hold(
         bytes32 holdId,
@@ -55,7 +55,7 @@ interface IERC20HoldableToken is IERC20 {
         uint256 amount,
         uint256 expirationDateTime,
         bytes32 lockHash
-    ) external returns (bool);
+    ) external;
 
     function retrieveHoldData(bytes32 holdId) external view returns (ERC20HoldData memory);
 

--- a/contracts/interface/IERC20HoldableToken.sol
+++ b/contracts/interface/IERC20HoldableToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/interface/IHoldableERC1400TokenExtension.sol
+++ b/contracts/interface/IHoldableERC1400TokenExtension.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "./HoldStatusCode.sol";

--- a/contracts/interface/IHoldableERC1400TokenExtension.sol
+++ b/contracts/interface/IHoldableERC1400TokenExtension.sol
@@ -9,7 +9,7 @@ interface IHoldableERC1400TokenExtension {
         bytes32 holdId,
         uint256 value,
         bytes32 lockPreimage
-    ) external returns (bool);
+    ) external;
 
     function retrieveHoldData(address token, bytes32 holdId) external view returns (
         bytes32 partition,

--- a/contracts/mocks/AllowlistMock.sol
+++ b/contracts/mocks/AllowlistMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO REACH FULL COVERAGE BY CALLING "onlyNotAllowlisted" MODIFIER

--- a/contracts/mocks/BlocklistMock.sol
+++ b/contracts/mocks/BlocklistMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO REACH FULL COVERAGE BY CALLING "onlyNotBlocklisted" MODIFIER

--- a/contracts/mocks/CertificateSignerMock.sol
+++ b/contracts/mocks/CertificateSignerMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO REACH FULL COVERAGE BY CALLING "onlyNotPausered" MODIFIER

--- a/contracts/mocks/Clock.sol
+++ b/contracts/mocks/Clock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO RETRIEVE TIME ON CHAIN

--- a/contracts/mocks/ERC1400TokensRecipientMock.sol
+++ b/contracts/mocks/ERC1400TokensRecipientMock.sol
@@ -25,7 +25,7 @@ contract ERC1400TokensRecipientMock is IERC1400TokensRecipient, ERC1820Implement
   ) // Comments to avoid compilation warnings for unused variables.
     external
     override
-    view
+    pure
     returns(bool)
   {
     return(_canReceive(from, to, value, data));
@@ -43,6 +43,7 @@ contract ERC1400TokensRecipientMock is IERC1400TokensRecipient, ERC1820Implement
   ) // Comments to avoid compilation warnings for unused variables.
     external
     override
+    pure
   {
     require(_canReceive(from, to, value, data), "57"); // 0x57	invalid receiver
   }

--- a/contracts/mocks/ERC1400TokensRecipientMock.sol
+++ b/contracts/mocks/ERC1400TokensRecipientMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../extensions/userExtensions/IERC1400TokensRecipient.sol";

--- a/contracts/mocks/ERC1400TokensSenderMock.sol
+++ b/contracts/mocks/ERC1400TokensSenderMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../extensions/userExtensions/IERC1400TokensSender.sol";

--- a/contracts/mocks/ERC1400TokensSenderMock.sol
+++ b/contracts/mocks/ERC1400TokensSenderMock.sol
@@ -24,7 +24,7 @@ contract ERC1400TokensSenderMock is IERC1400TokensSender, ERC1820Implementer {
     bytes calldata /*operatorData*/
   ) // Comments to avoid compilation warnings for unused variables.
     external
-    view
+    pure
     override
     returns(bool)
   {
@@ -42,6 +42,7 @@ contract ERC1400TokensSenderMock is IERC1400TokensSender, ERC1820Implementer {
     bytes calldata /*operatorData*/
   ) // Comments to avoid compilation warnings for unused variables.
     external
+    pure
     override
   {
     require(_canTransfer(from, to, value, data), "56"); // 0x56	invalid sender

--- a/contracts/mocks/ERC1400TokensValidatorMock.sol
+++ b/contracts/mocks/ERC1400TokensValidatorMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../extensions/tokenExtensions/ERC1400TokensValidator.sol";

--- a/contracts/mocks/FakeERC1400Mock.sol
+++ b/contracts/mocks/FakeERC1400Mock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../ERC1400.sol";

--- a/contracts/mocks/FakeERC1400Mock.sol
+++ b/contracts/mocks/FakeERC1400Mock.sol
@@ -36,7 +36,6 @@ contract FakeERC1400Mock is ERC1400 {
     address extension,
     address mockAddress
   )
-    public
     ERC1400(name, symbol, granularity, controllers, defaultPartitions)
   {
     if(extension != address(0)) {

--- a/contracts/mocks/MinterRoleMock.sol
+++ b/contracts/mocks/MinterRoleMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO REACH FULL COVERAGE BY CALLING "onlyMinter" MODIFIER

--- a/contracts/mocks/PauserMock.sol
+++ b/contracts/mocks/PauserMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // MOCK CONTRACT TO REACH FULL COVERAGE BY CALLING "onlyNotPausered" MODIFIER

--- a/contracts/roles/AllowlistAdminRole.sol
+++ b/contracts/roles/AllowlistAdminRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/AllowlistedRole.sol
+++ b/contracts/roles/AllowlistedRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/BlocklistAdminRole.sol
+++ b/contracts/roles/BlocklistAdminRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/BlocklistedRole.sol
+++ b/contracts/roles/BlocklistedRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/CertificateSignerRole.sol
+++ b/contracts/roles/CertificateSignerRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/MinterRole.sol
+++ b/contracts/roles/MinterRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/PauserRole.sol
+++ b/contracts/roles/PauserRole.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/roles/Roles.sol
+++ b/contracts/roles/Roles.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tokens/ERC1400HoldableToken.sol
+++ b/contracts/tokens/ERC1400HoldableToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../ERC1400.sol";

--- a/contracts/tokens/ERC1400HoldableToken.sol
+++ b/contracts/tokens/ERC1400HoldableToken.sol
@@ -51,7 +51,6 @@ contract ERC1400HoldableToken is ERC1400, IExtensionTypes {
     address extension,
     address newOwner
   )
-    public
     ERC1400(name, symbol, granularity, controllers, defaultPartitions)
   {
     if(extension != address(0)) {

--- a/contracts/tokens/ERC20HoldableToken.sol
+++ b/contracts/tokens/ERC20HoldableToken.sol
@@ -78,12 +78,12 @@ contract ERC20HoldableToken is ERC20Token, IERC20HoldableToken {
 
     /**
      @notice Called by the sender to hold some tokens for a recipient that the sender can not release back to themself until after the expiration date.
+     @param holdId a unique identifier for the hold.
      @param recipient optional account the tokens will be transferred to on execution. If a zero address, the recipient must be specified on execution of the hold.
      @param notary account that can execute the hold. Typically the recipient but can be a third party or a smart contact.
      @param amount of tokens to be transferred to the recipient on execution. Must be a non zero amount.
      @param expirationDateTime UNIX epoch seconds the held amount can be released back to the sender by the sender. Past dates are allowed.
      @param lockHash optional keccak256 hash of a lock preimage. An empty hash will not enforce the hash lock when the hold is executed.
-     @return holdId a unique identifier for the hold.
      */
     function hold(
         bytes32 holdId,
@@ -92,7 +92,7 @@ contract ERC20HoldableToken is ERC20Token, IERC20HoldableToken {
         uint256 amount,
         uint256 expirationDateTime,
         bytes32 lockHash
-    ) public override returns (bool) {
+    ) public override {
         require(
             notary != address(0),
             "hold: notary must not be a zero address"

--- a/contracts/tokens/ERC20HoldableToken.sol
+++ b/contracts/tokens/ERC20HoldableToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tokens/ERC20Token.sol
+++ b/contracts/tokens/ERC20Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/tokens/ERC721Token.sol
+++ b/contracts/tokens/ERC721Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/tools/BatchBalanceReader.sol
+++ b/contracts/tools/BatchBalanceReader.sol
@@ -27,7 +27,7 @@ interface IERC1400Extended {
 contract BatchBalanceReader is ERC1820Implementer {
     string internal constant BALANCE_READER = "BatchBalanceReader";
 
-    constructor() public {
+    constructor() {
         ERC1820Implementer._setInterface(BALANCE_READER);
     }
 

--- a/contracts/tools/BatchBalanceReader.sol
+++ b/contracts/tools/BatchBalanceReader.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tools/BatchReader.sol
+++ b/contracts/tools/BatchReader.sol
@@ -83,11 +83,11 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
             batchTotalSupplies[j] = IERC20(tokens[j]).totalSupply();
         }
 
-        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions, uint256[] memory batchPartitionSupplies) = batchTotalPartitions(tokens);
+        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions_, uint256[] memory batchPartitionSupplies) = batchTotalPartitions(tokens);
 
-        (uint256[] memory defaultPartitionsLengths, bytes32[] memory batchDefaultPartitions) = batchDefaultPartitions(tokens);
+        (uint256[] memory defaultPartitionsLengths, bytes32[] memory batchDefaultPartitions_) = batchDefaultPartitions(tokens);
 
-        return (batchTotalSupplies, totalPartitionsLengths, batchTotalPartitions, batchPartitionSupplies, defaultPartitionsLengths, batchDefaultPartitions);
+        return (batchTotalSupplies, totalPartitionsLengths, batchTotalPartitions_, batchPartitionSupplies, defaultPartitionsLengths, batchDefaultPartitions_);
     }
 
     /**
@@ -95,15 +95,15 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
      * @return Batch of token roles.
      */
     function batchTokenRolesInfos(address[] calldata tokens) external view returns (address[] memory, uint256[] memory, address[] memory, uint256[] memory, address[] memory) {
-        (uint256[] memory batchExtensionControllersLength, address[] memory batchExtensionControllers) = batchExtensionControllers(tokens);
+        (uint256[] memory batchExtensionControllersLength, address[] memory batchExtensionControllers_) = batchExtensionControllers(tokens);
 
-        (uint256[] memory batchControllersLength, address[] memory batchControllers) = batchControllers(tokens);
+        (uint256[] memory batchControllersLength, address[] memory batchControllers_) = batchControllers(tokens);
 
         address[] memory batchOwners = new address[](tokens.length);
         for (uint256 i = 0; i < tokens.length; i++) {
             batchOwners[i] = IERC1400Extended(tokens[i]).owner();
         }
-        return (batchOwners, batchControllersLength, batchControllers, batchExtensionControllersLength, batchExtensionControllers);
+        return (batchOwners, batchControllersLength, batchControllers_, batchExtensionControllersLength, batchExtensionControllers_);
     }
 
     /**
@@ -245,13 +245,13 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
     function batchERC1400Balances(address[] calldata tokens, address[] calldata tokenHolders) external view returns (uint256[] memory, uint256[] memory, uint256[] memory, bytes32[] memory, uint256[] memory, uint256[] memory) {
         (,, uint256[] memory batchSpendableBalancesOfByPartition) = batchSpendableBalanceOfByPartition(tokens, tokenHolders);
 
-        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions, uint256[] memory batchBalancesOfByPartition) = batchBalanceOfByPartition(tokens, tokenHolders);
+        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions_, uint256[] memory batchBalancesOfByPartition) = batchBalanceOfByPartition(tokens, tokenHolders);
 
         uint256[] memory batchBalancesOf = batchBalanceOf(tokens, tokenHolders);
 
         uint256[] memory batchEthBalances = batchEthBalance(tokenHolders);
 
-        return (batchEthBalances, batchBalancesOf, totalPartitionsLengths, batchTotalPartitions, batchBalancesOfByPartition, batchSpendableBalancesOfByPartition);
+        return (batchEthBalances, batchBalancesOf, totalPartitionsLengths, batchTotalPartitions_, batchBalancesOfByPartition, batchSpendableBalancesOfByPartition);
     }
 
     /**
@@ -333,21 +333,21 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
      * @return Batch of token partition balances.
      */
     function batchBalanceOfByPartition(address[] memory tokens, address[] memory tokenHolders) public view returns (uint256[] memory, bytes32[] memory, uint256[] memory) {
-        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions,) = batchTotalPartitions(tokens);
+        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions_,) = batchTotalPartitions(tokens);
         
-        uint256[] memory batchBalanceOfByPartitionResponse = new uint256[](tokenHolders.length * batchTotalPartitions.length);
+        uint256[] memory batchBalanceOfByPartitionResponse = new uint256[](tokenHolders.length * batchTotalPartitions_.length);
 
         for (uint256 i = 0; i < tokenHolders.length; i++) {
             uint256 counter = 0;
             for (uint256 j = 0; j < tokens.length; j++) {
                 for (uint256 k = 0; k < totalPartitionsLengths[j]; k++) {
-                    batchBalanceOfByPartitionResponse[i*batchTotalPartitions.length + counter] = IERC1400(tokens[j]).balanceOfByPartition(batchTotalPartitions[counter], tokenHolders[i]);
+                    batchBalanceOfByPartitionResponse[i*batchTotalPartitions_.length + counter] = IERC1400(tokens[j]).balanceOfByPartition(batchTotalPartitions_[counter], tokenHolders[i]);
                     counter++;
                 }
             }
         }
 
-        return (totalPartitionsLengths, batchTotalPartitions, batchBalanceOfByPartitionResponse);
+        return (totalPartitionsLengths, batchTotalPartitions_, batchBalanceOfByPartitionResponse);
     }
 
     /**
@@ -355,9 +355,9 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
      * @return Batch of token spendable partition balances.
      */
     function batchSpendableBalanceOfByPartition(address[] memory tokens, address[] memory tokenHolders) public view returns (uint256[] memory, bytes32[] memory, uint256[] memory) {
-        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions,) = batchTotalPartitions(tokens);
+        (uint256[] memory totalPartitionsLengths, bytes32[] memory batchTotalPartitions_,) = batchTotalPartitions(tokens);
         
-        uint256[] memory batchSpendableBalanceOfByPartitionResponse = new uint256[](tokenHolders.length * batchTotalPartitions.length);
+        uint256[] memory batchSpendableBalanceOfByPartitionResponse = new uint256[](tokenHolders.length * batchTotalPartitions_.length);
 
         for (uint256 i = 0; i < tokenHolders.length; i++) {
             uint256 counter = 0;
@@ -366,16 +366,16 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
 
                 for (uint256 k = 0; k < totalPartitionsLengths[j]; k++) {
                     if (tokenExtension != address(0)) {
-                        batchSpendableBalanceOfByPartitionResponse[i*batchTotalPartitions.length + counter] = IERC1400TokensValidatorExtended(tokenExtension).spendableBalanceOfByPartition(tokens[j], batchTotalPartitions[counter], tokenHolders[i]);
+                        batchSpendableBalanceOfByPartitionResponse[i*batchTotalPartitions_.length + counter] = IERC1400TokensValidatorExtended(tokenExtension).spendableBalanceOfByPartition(tokens[j], batchTotalPartitions_[counter], tokenHolders[i]);
                     } else {
-                        batchSpendableBalanceOfByPartitionResponse[i*batchTotalPartitions.length + counter] = IERC1400(tokens[j]).balanceOfByPartition(batchTotalPartitions[counter], tokenHolders[i]);
+                        batchSpendableBalanceOfByPartitionResponse[i*batchTotalPartitions_.length + counter] = IERC1400(tokens[j]).balanceOfByPartition(batchTotalPartitions_[counter], tokenHolders[i]);
                     }
                     counter++;
                 }
             }
         }
 
-        return (totalPartitionsLengths, batchTotalPartitions, batchSpendableBalanceOfByPartitionResponse);
+        return (totalPartitionsLengths, batchTotalPartitions_, batchSpendableBalanceOfByPartitionResponse);
     }
 
     /**
@@ -443,10 +443,10 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
      * @return Batch of validation status.
      */
     function batchValidations(address[] memory tokens, address[] memory tokenHolders) public view returns (bool[] memory, bool[] memory) {
-        bool[] memory batchAllowlisted = batchAllowlisted(tokens, tokenHolders);
-        bool[] memory batchBlocklisted = batchBlocklisted(tokens, tokenHolders);
+        bool[] memory batchAllowlisted_ = batchAllowlisted(tokens, tokenHolders);
+        bool[] memory batchBlocklisted_ = batchBlocklisted(tokens, tokenHolders);
 
-        return (batchAllowlisted, batchBlocklisted);
+        return (batchAllowlisted_, batchBlocklisted_);
     }
 
     /**

--- a/contracts/tools/BatchReader.sol
+++ b/contracts/tools/BatchReader.sol
@@ -69,7 +69,7 @@ contract BatchReader is IExtensionTypes, ERC1820Client, ERC1820Implementer {
     // Mapping from token to token extension address
     mapping(address => address) internal _extension;
 
-    constructor() public {
+    constructor() {
         ERC1820Implementer._setInterface(BALANCE_READER);
     }
 

--- a/contracts/tools/BatchReader.sol
+++ b/contracts/tools/BatchReader.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tools/BatchTokenIssuer.sol
+++ b/contracts/tools/BatchTokenIssuer.sol
@@ -62,7 +62,6 @@ contract BatchTokenIssuer is ERC1820Implementer {
   )
     external
     onlyTokenMinter(token)
-    returns (uint256[] memory)
   {
     require(partitions.length == tokenHolders.length, "partitions and tokenHolders arrays have different lengths");
     require(partitions.length == values.length, "partitions and values arrays have different lengths");

--- a/contracts/tools/BatchTokenIssuer.sol
+++ b/contracts/tools/BatchTokenIssuer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tools/BatchTokenIssuer.sol
+++ b/contracts/tools/BatchTokenIssuer.sol
@@ -43,7 +43,7 @@ contract BatchTokenIssuer is ERC1820Implementer {
     _;
   }
 
-  constructor() public {
+  constructor() {
     ERC1820Implementer._setInterface(BATCH_ISSUER);
   }
 

--- a/contracts/tools/DomainAware.sol
+++ b/contracts/tools/DomainAware.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tools/ERC1820Client.sol
+++ b/contracts/tools/ERC1820Client.sol
@@ -1,4 +1,4 @@
-
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/introspection/IERC1820Registry.sol";

--- a/contracts/tools/FundIssuer.sol
+++ b/contracts/tools/FundIssuer.sol
@@ -166,7 +166,7 @@ contract FundIssuer is ERC1820Client, IERC1400TokensRecipient, ERC1820Implemente
    * @dev Initialize Fund issuance contract + register
    * the contract implementation in ERC1820Registry.
    */
-  constructor() public {
+  constructor() {
     ERC1820Implementer._setInterface(FUND_ISSUER);
     ERC1820Implementer._setInterface(ERC1400_TOKENS_RECIPIENT);
     setInterfaceImplementation(ERC1400_TOKENS_RECIPIENT, address(this));

--- a/contracts/tools/FundIssuer.sol
+++ b/contracts/tools/FundIssuer.sol
@@ -179,7 +179,7 @@ contract FundIssuer is ERC1820Client, IERC1400TokensRecipient, ERC1820Implemente
    * @param operatorData Information attached to the Swaps transfer, by the operator.
    * @return 'true' if the Swaps contract can receive the tokens, 'false' if not.
    */
-  function canReceive(bytes calldata, bytes32, address, address, address, uint, bytes calldata  data, bytes calldata operatorData) external override view returns(bool) {
+  function canReceive(bytes calldata, bytes32, address, address, address, uint, bytes calldata  data, bytes calldata operatorData) external override pure returns(bool) {
     return(_canReceive(data, operatorData));
   }
 

--- a/contracts/tools/FundIssuer.sol
+++ b/contracts/tools/FundIssuer.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.

--- a/contracts/tools/Pausable.sol
+++ b/contracts/tools/Pausable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "../roles/PauserRole.sol";

--- a/contracts/tools/Swaps.sol
+++ b/contracts/tools/Swaps.sol
@@ -266,7 +266,7 @@ contract Swaps is Ownable, ERC1820Client, IERC1400TokensRecipient, ERC1820Implem
    * @param operatorData Information attached to the Swaps transfer, by the operator.
    * @return 'true' if the Swaps contract can receive the tokens, 'false' if not.
    */
-  function canReceive(bytes calldata, bytes32, address, address, address, uint, bytes calldata  data, bytes calldata operatorData) external override view returns(bool) {
+  function canReceive(bytes calldata, bytes32, address, address, address, uint, bytes calldata  data, bytes calldata operatorData) external override pure returns(bool) {
     return(_canReceive(data, operatorData));
   }
 

--- a/contracts/tools/Swaps.sol
+++ b/contracts/tools/Swaps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This code has not been reviewed.
  * Do not use or deploy this code before reviewing it personally first.


### PR DESCRIPTION
## Description

Address all compile warnings that `solc` provides when compiling contracts. 

## Motivation and Context

After forking repo & running `nvm use && yarn`, we see a bunch of `solc` compiler warnings that as of now can't be disabled (see [here](https://github.com/ethereum/solidity/issues/2691) & [here](https://github.com/ethereum/solidity/issues/2675)). This presents a problem for developers who are using the `UniversalToken/` library because they have noisy outputs when compiling contracts; other important warnings/errors can be lost in the noise.

## How Has This Been Tested?

Ran `yarn coverage` successfully.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
